### PR TITLE
Add step to expose GitHub Actions Runtime before dotnet test

### DIFF
--- a/build-and-test/action.yml
+++ b/build-and-test/action.yml
@@ -78,6 +78,13 @@ runs:
             exit 1
           }
         }
+    - name: Expose GitHub Actions Runtime
+      if: ${{ inputs.run-tests == 'true' }}
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
+          core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
     - name: Test
       if: ${{ inputs.run-tests == 'true' }}
       shell: bash


### PR DESCRIPTION
Inserts the `Expose GitHub Actions Runtime` step before `dotnet test` in the `build-and-test` action. This exports `ACTIONS_RUNTIME_TOKEN` and `ACTIONS_RESULTS_URL` environment variables, enabling test result reporting to GitHub Actions during `dotnet test` execution.

The step is gated behind the same `run-tests == 'true'` condition as the test step itself.

This enables the [TUnit GitHub Actions HTML report integration](https://tunit.dev/docs/guides/html-report/#github-actions-integration).